### PR TITLE
HTML demo of /autocomplete for a typeahead experience

### DIFF
--- a/examples/javascript/autocomplete/README.md
+++ b/examples/javascript/autocomplete/README.md
@@ -1,0 +1,5 @@
+A small demo HTML page using [jquery-typeahead](https://github.com/running-coder/jquery-typeahead)
+to match titles to a partial input and, on selection, open the paper on semanticscholar.org 
+
+S2 APIs involved:
+* [/graph/v1/paper/autocomplete](https://api.semanticscholar.org/api-docs/#tag/Paper-Data/operation/get_graph_get_paper_autocomplete)

--- a/examples/javascript/autocomplete/README.md
+++ b/examples/javascript/autocomplete/README.md
@@ -1,5 +1,8 @@
 A small demo HTML page using [jquery-typeahead](https://github.com/running-coder/jquery-typeahead)
 to match titles to a partial input and, on selection, open the paper on semanticscholar.org 
 
+You can view the demo here: https://rawcdn.githack.com/allenai/s2-folks/main/examples/javascript/autocomplete/index.html
+
 S2 APIs involved:
 * [/graph/v1/paper/autocomplete](https://api.semanticscholar.org/api-docs/#tag/Paper-Data/operation/get_graph_get_paper_autocomplete)
+

--- a/examples/javascript/autocomplete/index.html
+++ b/examples/javascript/autocomplete/index.html
@@ -22,9 +22,12 @@
     </div>
 </form>
 <script>
+    // docs host is gone, use archive.org
+    // https://web.archive.org/web/20230306015242/http://www.runningcoder.org/jquerytypeahead/
     $.typeahead({
         input: '.js-typeahead',
         display: ['title'],
+        filter: false,
         source: {
             callApi: {
                 ajax: {

--- a/examples/javascript/autocomplete/index.html
+++ b/examples/javascript/autocomplete/index.html
@@ -26,8 +26,9 @@
     // https://web.archive.org/web/20230306015242/http://www.runningcoder.org/jquerytypeahead/
     $.typeahead({
         input: '.js-typeahead',
-        display: ['title'],
-        filter: false,
+        dynamic: true,
+        filter: false,  // disable client-side filtering
+        minLength: 3,  // api requires at least 3 chars
         source: {
             callApi: {
                 ajax: {
@@ -39,7 +40,7 @@
                 }
             }
         },
-        dynamic: true,
+        display: ['title'],
         callback: {
             onClick: function(node, a, item, event) {
                 window.open(`https://api.semanticscholar.org/${item.id}`, '_blank')

--- a/examples/javascript/autocomplete/index.html
+++ b/examples/javascript/autocomplete/index.html
@@ -1,0 +1,48 @@
+<html>
+<head>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.0/jquery.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-typeahead/2.11.2/jquery.typeahead.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-typeahead/2.11.2/jquery.typeahead.min.css">
+</head>
+<body>
+<form>
+    <div class="typeahead__container">
+        <div class="typeahead__field">
+            <div class="typeahead__query">
+                <input class="js-typeahead"
+                       name="q"
+                       autocomplete="off">
+            </div>
+            <div class="typeahead__button">
+                <button type="submit">
+                    <span class="typeahead__search-icon"></span>
+                </button>
+            </div>
+        </div>
+    </div>
+</form>
+<script>
+    $.typeahead({
+        input: '.js-typeahead',
+        display: ['title'],
+        source: {
+            callApi: {
+                ajax: {
+                    url: 'https://api.semanticscholar.org/graph/v1/paper/autocomplete',
+                    data: {
+                        query: '{{query}}'
+                    },
+                    path: 'matches',
+                }
+            }
+        },
+        dynamic: true,
+        callback: {
+            onClick: function(node, a, item, event) {
+                window.open(`https://api.semanticscholar.org/${item.id}`, '_blank')
+            }
+        }
+    })
+</script>
+</body>
+</html>


### PR DESCRIPTION
You can view the demo here https://rawcdn.githack.com/allenai/s2-folks/jason/autocomplete-ex/examples/javascript/autocomplete/index.html

link in readme won't work until merged to main

<img width="466" alt="Screenshot 2023-05-24 at 4 16 45 PM" src="https://github.com/allenai/s2-folks/assets/487920/bda705d2-88d0-4b55-9718-44dda42b7c34">
