### PR TITLE
Fix bugs for get_open_access_pdf

### DIFF
--- a/examples/python/get_open_access_pdf/parallel.py
+++ b/examples/python/get_open_access_pdf/parallel.py
@@ -77,11 +77,10 @@ async def download_papers(paper_ids: list[str], directory: str = 'papers', batch
             if not paper['isOpenAccess']:
                 yield paper_id, None
 
-            paperId: str = paper['paperId']
-            pdf_url: str = paper['openAccessPdf']['url']
-            pdf_path = os.path.join(directory, f'{paperId}.pdf')
-
             try:
+                paperId: str = paper['paperId']
+                pdf_url: str = paper['openAccessPdf']['url']
+                pdf_path = os.path.join(directory, f'{paperId}.pdf')
                 await download_pdf(session, pdf_url, pdf_path)
                 yield paper_id, pdf_path
             except Exception as e:

--- a/examples/python/get_open_access_pdf/simple.py
+++ b/examples/python/get_open_access_pdf/simple.py
@@ -54,6 +54,9 @@ def download_paper(session: Session, paper_id: str, directory: str = 'papers', u
     if not paper['isOpenAccess']:
         return None
 
+    if pdf_url: str = paper['openAccessPdf'] is None:
+        return None
+
     paperId: str = paper['paperId']
     pdf_url: str = paper['openAccessPdf']['url']
     pdf_path = os.path.join(directory, f'{paperId}.pdf')

--- a/examples/python/get_open_access_pdf/simple.py
+++ b/examples/python/get_open_access_pdf/simple.py
@@ -54,7 +54,7 @@ def download_paper(session: Session, paper_id: str, directory: str = 'papers', u
     if not paper['isOpenAccess']:
         return None
 
-    if pdf_url: str = paper['openAccessPdf'] is None:
+    if paper['openAccessPdf'] is None:
         return None
 
     paperId: str = paper['paperId']


### PR DESCRIPTION
Even when `paper['isOpenAccess']` is `True`, the `paper['openAccessPdf']` can still be `None`.

Example paper ids: `["68d4427906b35189333ea4619234adc3aba5e2d2", "2af2d1b441b268dc98afbd9bbfb57867beb5b2ef"]`.