### PR TITLE
Example of using bulk search

### DIFF
--- a/examples/python/search_bulk/README.md
+++ b/examples/python/search_bulk/README.md
@@ -1,0 +1,9 @@
+S2 APIs involved:
+* [GET /graph/v1/paper/search/bulk](https://api.semanticscholar.org/api-docs/graph#tag/Paper-Data/operation/get_graph_get_paper_bulk)
+
+This example fetches a subset of paper data specified by a simple query and writes a JSON-lines archive of the results.
+
+To run:
+```
+python get_sturgeon_dataset.py
+```

--- a/examples/python/search_bulk/get_dataset.py
+++ b/examples/python/search_bulk/get_dataset.py
@@ -4,7 +4,7 @@ import json
 query = "(cold -temperature) | flu"
 fields = "title,year"
 
-url = f"http://api-dev.semanticscholar.org/graph/v1/paper/search/bulk?query={query}&fields={fields}&year=2023-"
+url = f"http://api.semanticscholar.org/graph/v1/paper/search/bulk?query={query}&fields={fields}&year=2023-"
 r = requests.get(url).json()
 
 print(f"Will retrieve an estimated {r['total']} documents")

--- a/examples/python/search_bulk/get_sturgeon_dataset.py
+++ b/examples/python/search_bulk/get_sturgeon_dataset.py
@@ -1,24 +1,24 @@
 import requests
 import json
 
-query = "sturgeon"
+query = "(cold -temperature) | flu"
 fields = "title,year"
 
-url = f"http://api-dev.semanticscholar.org/graph/v1/paper/search/bulk?query={query}&fields={fields}"
+url = f"http://api-dev.semanticscholar.org/graph/v1/paper/search/bulk?query={query}&fields={fields}&year=2023-"
 r = requests.get(url).json()
 
-print(f"Will retrieve {r['total']} documents")
+print(f"Will retrieve an estimated {r['total']} documents")
 retrieved = 0
 
-with open(f"{query}.jsonl", "a") as file:
+with open(f"papers.jsonl", "a") as file:
     while True:
-        for paper in r["data"]:
-            print(json.dumps(paper), file=file)
-        token = r["token"]
-        if token:
+        if "data" in r:
             retrieved += len(r["data"])
             print(f"Retrieved {retrieved} papers...")
-        else:
+            for paper in r["data"]:
+                print(json.dumps(paper), file=file)
+        if "token" not in r:
             break
-        r = requests.get(f"{url}&token={token}").json()
-print("Done!")
+        r = requests.get(f"{url}&token={r['token']}").json()
+
+print(f"Done! Retrieved {retrieved} papers total")

--- a/examples/python/search_bulk/get_sturgeon_dataset.py
+++ b/examples/python/search_bulk/get_sturgeon_dataset.py
@@ -2,9 +2,9 @@ import requests
 import json
 
 query = "sturgeon"
-fields="title,year"
+fields = "title,year"
 
-url = f'http://api-dev.semanticscholar.org/graph/v1/paper/search/bulk?query={query}&fields={fields}'
+url = f"http://api-dev.semanticscholar.org/graph/v1/paper/search/bulk?query={query}&fields={fields}"
 r = requests.get(url).json()
 
 print(f"Will retrieve {r['total']} documents")
@@ -12,13 +12,13 @@ retrieved = 0
 
 with open(f"{query}.jsonl", "a") as file:
     while True:
-        for paper in r['data']:
+        for paper in r["data"]:
             print(json.dumps(paper), file=file)
-        token = r['token']
+        token = r["token"]
         if token:
-            retrieved += len(r['data'])
+            retrieved += len(r["data"])
             print(f"Retrieved {retrieved} papers...")
         else:
             break
-        r = requests.get(f'{url}&token={token}').json()
+        r = requests.get(f"{url}&token={token}").json()
 print("Done!")

--- a/examples/python/search_bulk/get_sturgeon_dataset.py
+++ b/examples/python/search_bulk/get_sturgeon_dataset.py
@@ -1,0 +1,24 @@
+import requests
+import json
+
+query = "sturgeon"
+fields="title,year"
+
+url = f'http://api-dev.semanticscholar.org/graph/v1/paper/search/bulk?query={query}&fields={fields}'
+r = requests.get(url).json()
+
+print(f"Will retrieve {r['total']} documents")
+retrieved = 0
+
+with open(f"{query}.jsonl", "a") as file:
+    while True:
+        for paper in r['data']:
+            print(json.dumps(paper), file=file)
+        token = r['token']
+        if token:
+            retrieved += len(r['data'])
+            print(f"Retrieved {retrieved} papers...")
+        else:
+            break
+        r = requests.get(f'{url}&token={token}').json()
+print("Done!")

--- a/examples/python/search_bulk/requirements.txt
+++ b/examples/python/search_bulk/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
Adds an example script that pulls down a small corpus using search bulk.

Usage:

```
milesc@rainier 0 search_bulk ↠ python3 get_sturgeon_dataset.py
Will retrieve 11882 documents
Retrieved 1000 papers...
Retrieved 2000 papers...
Retrieved 3000 papers...
Retrieved 4000 papers...
Retrieved 5000 papers...
Retrieved 6000 papers...
Retrieved 6999 papers...
Retrieved 7999 papers...
Retrieved 8999 papers...
Retrieved 9999 papers...
Retrieved 10999 papers...
Done!

milesc@rainier 0 search_bulk ↠ head sturgeon.jsonl
{"paperId": "00000bb81d515d106dcd455357c1bae69a0eb1ee", "title": "Effect of chemical and physical factors on infectivity of Siberian sturgeon herpesvirus", "year": 2010}
{"paperId": "00045cbc571588950a22774175a7c06abec0be89", "title": "Marine Migration of North American Green Sturgeon", "year": 2008}
{"paperId": "000698bb3e1b9c75e3d78be9ab0d56dbe1e7514e", "title": "Amino Acid Composition in Different Parts of Farmed Sturgeon Acipenser schrenckii", "year": 2006}
...
```