### PR TITLE
force gunzip in s2ag test script

### DIFF
--- a/examples/python/s2ag_datasets/get_sample_files.sh
+++ b/examples/python/s2ag_datasets/get_sample_files.sh
@@ -6,4 +6,4 @@ for f in $(curl -s https://s3-us-west-2.amazonaws.com/ai2-s2ag/samples/MANIFEST.
   echo "$f"
 done
 
-gunzip -q samples/*/*.gz
+gunzip -qf samples/*/*.gz


### PR DESCRIPTION
add force flag to gunzip to overwrite any files already there. this makes running this particular test script repeatable without a manual `rm` between runs