### PR TITLE
Update API_RELEASE_NOTES.md

### DIFF
--- a/API_RELEASE_NOTES.md
+++ b/API_RELEASE_NOTES.md
@@ -1,3 +1,30 @@
+# **November**
+
+### **Breaking Changes**
+* **Field Deprecation - Aliases**
+  * Starting in January of next year we will not longer support the Aliases field.
+
+* **Ongoing Reminder: Deprecation of partner.semanticscholar.org**
+  * In December 2023 we will turn off access to partner.semanticscholar.org 
+  * Ensure that you replace "partner.semanticscholar.org" with "api.semanticscholar.org" in all URLs before the cutoff date.
+
+### **New Features**
+* **New Field: contextsWithIntent**
+  * Similar to "contexts" but each context comes its associated intents. Each object returned in this list has two keys: 'context' - the text snippet, and 'intents' - associated intents for this context. For example 
+                    '{
+                        "context": "SciBERT (Beltagy et al., 2019) follows the BERT’s ...",
+                        "intent": "methodology", }'
+
+### Performance Improvements
+* **Ongoing Reminder API Rate limit**
+  * Unauthenticated: All unauthenticated users share a limit of 5,000 requests per 5 minutes.
+  * Authenticated: 1 request per second for: /paper/batch, /paper/search, /recommendations and 10 requests / second for all other calls
+
+### Other Changes
+* **Ongoing Reminder: Springer abstracts**
+  * Users have commented that our Public API does not show an abstract for Springer papers. This is intentional due to requirements of our agreement with Springer
+
+
 # **October 1, 2023 - October 31, 2023**
 
 ### **Breaking Changes**


### PR DESCRIPTION
Updates for completed and planned changes to Semantic Scholar's public API reflecting work during the month of November 2023.